### PR TITLE
Fix templated security.yml (was truncated)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,1 +1,13 @@
 name: "Security Scanning"
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+jobs:
+  scan:
+    name: Security Scan
+    uses: chrisns/.github/.github/workflows/security-scan.yml@main
+    permissions:
+      security-events: write
+      statuses: write


### PR DESCRIPTION
Templated file got truncated by an indentation bug in chrisns/.github repo-config.yml — restoring full content.